### PR TITLE
댓글 컴포넌트 리팩터링

### DIFF
--- a/components/post/PostBody/PostBody.tsx
+++ b/components/post/PostBody/PostBody.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { Post, PostCategory } from '@/types/post';
 import { decodeHTML } from '@/utils/post';
 import { getGatheringDate } from '@/utils/date';
-import ReplyList from '@/components/reply/ReplyList';
 import ReplyForm from '@/components/reply/ReplyForm';
+import PostReplyList from '../PostReplyList';
 
 import * as Styled from './PostBody.styled';
 
@@ -31,7 +31,7 @@ export default function PostBody({ post }: PostBodyProps) {
       <Styled.ReplyWrapper>
         <h2>댓글</h2>
         <ReplyForm postId={post.id} />
-        <ReplyList postId={post.id} />
+        <PostReplyList postId={post.id} />
       </Styled.ReplyWrapper>
     </Styled.PostBodyContainer>
   );

--- a/components/post/PostReplyItem/PostReplyItem.styled.ts
+++ b/components/post/PostReplyItem/PostReplyItem.styled.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const ReplyOfReplyWrapper = styled.div`
+  padding-left: 3rem;
+`;

--- a/components/post/PostReplyItem/PostReplyItem.tsx
+++ b/components/post/PostReplyItem/PostReplyItem.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { Reply } from '@/types/reply';
+import { ReplySchema } from '@/constants/schema';
+
+import useToggle from '@/hooks/useToggle';
+import ReplyForm from '@/components/reply/ReplyForm';
+import ReplyItem from '@/components/reply/ReplyItem';
+import useUpdateReplyMutation from '@/components/reply/hooks/useUpdateReplyMutation';
+import useDeleteReplyMutation from '@/components/reply/hooks/useDeleteReplyMutation';
+
+import PostReplyList from '../PostReplyList/PostReplyList';
+import { usePostReplyListContext } from '../contexts/PostReplyListContext';
+
+import * as Styled from './PostReplyItem.styled';
+
+interface PostReplyItemProps {
+  reply: Reply;
+}
+
+export default function PostReplyItem({ reply }: PostReplyItemProps) {
+  const { toggle: isEditable, onToggle: onToggleIsEditable } = useToggle(false);
+  const { mutate: updateReply } = useUpdateReplyMutation(reply);
+  const { mutate: deleteReply } = useDeleteReplyMutation(reply);
+  const { isOpenReplyForm, openReplyForm } =
+    usePostReplyListContext('PostReplyItem');
+
+  function onUpdate(data: ReplySchema) {
+    updateReply(data.content, {
+      onSuccess: () => {
+        onToggleIsEditable();
+      },
+    });
+  }
+
+  const onDelete = () => {
+    const isConfirm = window.confirm('정말로 삭제하시겠습니까?');
+    if (isConfirm) {
+      deleteReply(reply);
+    }
+  };
+
+  return (
+    <>
+      <ReplyItem reply={reply}>
+        {!isEditable && (
+          <ReplyItem.Dropdown
+            onUpdate={onToggleIsEditable}
+            onDelete={onDelete}
+          />
+        )}
+        {isEditable ? (
+          <ReplyItem.ContentEditor
+            onUpdate={onUpdate}
+            onCancel={onToggleIsEditable}
+          />
+        ) : (
+          <ReplyItem.Content onOpenReplyForm={() => openReplyForm(reply.id)} />
+        )}
+      </ReplyItem>
+      <Styled.ReplyOfReplyWrapper>
+        {isOpenReplyForm === reply.id && (
+          <ReplyForm
+            postId={reply.postId}
+            replyId={reply.id}
+            onCancel={() => openReplyForm(null)}
+          />
+        )}
+        <PostReplyList postId={reply.postId} replyId={reply.id} />
+      </Styled.ReplyOfReplyWrapper>
+    </>
+  );
+}

--- a/components/post/PostReplyItem/index.ts
+++ b/components/post/PostReplyItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PostReplyItem';

--- a/components/post/PostReplyList/PostReplyList.tsx
+++ b/components/post/PostReplyList/PostReplyList.tsx
@@ -1,16 +1,16 @@
 import React, { useCallback } from 'react';
 
 import InView from '@/components/shared/InView';
+import PostReplyItem from '@/components/post/PostReplyItem';
 import useGetRepliesQuery from '@/components/reply/hooks/useGetRepliesQuery';
-import ReplyItem from '../ReplyItem';
-import ReplyListContextProvider from '../contexts/ReplyListContext';
+import PostReplyListContext from '../contexts/PostReplyListContext';
 
-interface ReplyListProps {
+interface PostReplyListProps {
   postId: number | string;
   replyId?: number | string;
 }
 
-export default function ReplyList({ postId, replyId }: ReplyListProps) {
+export default function PostReplyList({ postId, replyId }: PostReplyListProps) {
   const { data, fetchNextPage, hasNextPage, isFetching } = useGetRepliesQuery({
     postId,
     replyId,
@@ -26,18 +26,18 @@ export default function ReplyList({ postId, replyId }: ReplyListProps) {
   );
 
   return (
-    <ReplyListContextProvider>
+    <PostReplyListContext>
       <InView onChange={onChange} threshold={0.5}>
         <ul>
           {data?.pages.map((page) =>
             page.map((reply) => (
               <li key={reply.id}>
-                <ReplyItem reply={reply} />
+                <PostReplyItem reply={reply} />
               </li>
             )),
           )}
         </ul>
       </InView>
-    </ReplyListContextProvider>
+    </PostReplyListContext>
   );
 }

--- a/components/post/PostReplyList/index.ts
+++ b/components/post/PostReplyList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PostReplyList';

--- a/components/post/contexts/PostReplyListContext.tsx
+++ b/components/post/contexts/PostReplyListContext.tsx
@@ -1,29 +1,31 @@
 import { createContext, useCallback, useContext, useState } from 'react';
 
-interface ReplyListContextState {
+interface PostReplyListContextState {
   isOpenReplyForm: string | number | null;
   openReplyForm: (replyId: string | number | null) => void;
 }
 
-const ReplyListContext = createContext<ReplyListContextState | null>(null);
+const PostReplyListContext = createContext<PostReplyListContextState | null>(
+  null,
+);
 
-export function useReplyListContext(componentName: string) {
-  const context = useContext(ReplyListContext);
+export function usePostReplyListContext(componentName: string) {
+  const context = useContext(PostReplyListContext);
   if (!context) {
     throw new Error(
-      `<${componentName} /> is missing a parent <ReplyListContextProvider /> component.`,
+      `<${componentName} /> is missing a parent <PostReplyListContextProvider /> component.`,
     );
   }
   return context;
 }
 
-interface ReplyListContextProviderProps {
+interface PostReplyListContextProviderProps {
   children?: React.ReactNode;
 }
 
 export default function ReplyListContextProvider({
   children,
-}: ReplyListContextProviderProps) {
+}: PostReplyListContextProviderProps) {
   const [isOpenReplyForm, setIsOpenReplyForm] = useState<
     string | number | null
   >(null);
@@ -33,8 +35,8 @@ export default function ReplyListContextProvider({
   }, []);
 
   return (
-    <ReplyListContext.Provider value={{ openReplyForm, isOpenReplyForm }}>
+    <PostReplyListContext.Provider value={{ openReplyForm, isOpenReplyForm }}>
       {children}
-    </ReplyListContext.Provider>
+    </PostReplyListContext.Provider>
   );
 }

--- a/components/reply/ReplyItem/ReplyItem.styled.ts
+++ b/components/reply/ReplyItem/ReplyItem.styled.ts
@@ -21,6 +21,7 @@ export const ProfileImageWrapper = styled.div`
 `;
 
 export const ContentWrapper = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -72,6 +73,8 @@ export const UtilWrapper = styled.div`
   color: ${({ theme }) => theme.colors.gray[600]};
 `;
 
+export const ReplyContentEditorContainer = styled.div``;
+
 export const ContentTextArea = styled(ResizableTextArea)`
   width: 100%;
   border: 0;
@@ -88,8 +91,4 @@ export const EditUtilWrapper = styled.div`
   justify-content: flex-end;
   column-gap: 0.5rem;
   margin-bottom: 1rem;
-`;
-
-export const ReplyOfReplyWrapper = styled.div`
-  padding-left: 3rem;
 `;

--- a/components/reply/ReplyItem/ReplyItem.tsx
+++ b/components/reply/ReplyItem/ReplyItem.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import Image from 'next/image';
-import { format } from 'date-fns';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useSelector } from 'react-redux';
@@ -9,96 +8,63 @@ import { AppState } from '@/store/index';
 import { Reply } from '@/types/reply';
 import { elapsedTime } from '@/utils/date';
 import { ReplySchema, REPLY_SCHEMA } from '@/constants/schema';
-import useToggle from '@/hooks/useToggle';
-import Button from '@/components/shared/Button';
 import SVGIcon from '@/components/shared/SVGIcon';
+import Button from '@/components/shared/Button';
 import Dropdown from '@/components/shared/Dropdown';
-
-import ReplyForm from '../ReplyForm';
-import ReplyList from '../ReplyList';
-import useUpdateReplyMutation from '../hooks/useUpdateReplyMutation';
-import useDeleteReplyMutation from '../hooks/useDeleteReplyMutation';
-import { useReplyListContext } from '../contexts/ReplyListContext';
 
 import * as Styled from './ReplyItem.styled';
 
-interface ReplyItemProps {
+interface ReplyItemContextState {
   reply: Reply;
 }
 
-export default function ReplyItem({ reply }: ReplyItemProps) {
-  const { user } = useSelector((state: AppState) => state.user);
-  const { isOpenReplyForm, openReplyForm } = useReplyListContext('ReplyItem');
-  const { toggle: isEditable, onToggle: onToggleIsEditable } = useToggle(false);
-  const { mutate: updateReply } = useUpdateReplyMutation(reply);
-  const { mutate: deleteReply } = useDeleteReplyMutation(reply);
+const ReplyItemContext = createContext<ReplyItemContextState | null>(null);
 
-  const isAuthor = useMemo(() => user?.loginId === reply.userId, [user, reply]);
-  const onUpdate = (data: ReplySchema) => {
-    updateReply(data.content, {
-      onSuccess: () => {
-        onToggleIsEditable();
-      },
-    });
-  };
+function useReplyItemContext(componentName: string) {
+  const context = useContext(ReplyItemContext);
+  if (!context) {
+    throw new Error(
+      `<${componentName} /> is missing a parent <ReplyItem /> component.`,
+    );
+  }
+  return context;
+}
 
-  const onDelete = () => {
-    deleteReply(reply);
-  };
+interface ReplyItemProps {
+  reply: Reply;
+  children?: React.ReactNode;
+}
 
+function ReplyItem({ reply, children }: ReplyItemProps) {
   return (
-    <Styled.ReplyItemContainer>
-      <Styled.ReplyItemWrapper>
-        <Styled.ProfileImageWrapper>
-          <Image src="/images/profile.png" alt="프로필 이미지" layout="fill" />
-        </Styled.ProfileImageWrapper>
-        <Styled.ContentWrapper>
-          <Styled.Author>
-            {isEditable && <Styled.EditIndicator>수정중</Styled.EditIndicator>}
-            {reply.userId}
-          </Styled.Author>
-          {!isEditable && <ReplyContent reply={reply} />}
-          {isEditable && (
-            <ReplyContentEditor
-              reply={reply}
-              onUpdate={onUpdate}
-              onCancel={onToggleIsEditable}
+    <ReplyItemContext.Provider value={{ reply }}>
+      <Styled.ReplyItemContainer>
+        <Styled.ReplyItemWrapper>
+          <Styled.ProfileImageWrapper>
+            <Image
+              src="/images/profile.png"
+              alt="프로필 이미지"
+              layout="fill"
             />
-          )}
-        </Styled.ContentWrapper>
-        <Styled.UtilWrapper>
-          {isAuthor && !isEditable && (
-            <Dropdown>
-              <Dropdown.Button>
-                <SVGIcon icon="MoreVerticalIcon" />
-              </Dropdown.Button>
-              <Dropdown.Items width="8rem">
-                <Dropdown.Item onClick={onToggleIsEditable}>
-                  수정하기
-                </Dropdown.Item>
-                <Dropdown.Item onClick={onDelete}>삭제하기</Dropdown.Item>
-              </Dropdown.Items>
-            </Dropdown>
-          )}
-        </Styled.UtilWrapper>
-      </Styled.ReplyItemWrapper>
-      <Styled.ReplyOfReplyWrapper>
-        {isOpenReplyForm === reply.id && (
-          <ReplyForm
-            postId={reply.postId}
-            replyId={reply.id}
-            onCancel={() => openReplyForm(null)}
-          />
-        )}
-        <ReplyList postId={reply.postId} replyId={reply.id} />
-      </Styled.ReplyOfReplyWrapper>
-    </Styled.ReplyItemContainer>
+          </Styled.ProfileImageWrapper>
+          <Styled.ContentWrapper>{children}</Styled.ContentWrapper>
+        </Styled.ReplyItemWrapper>
+      </Styled.ReplyItemContainer>
+    </ReplyItemContext.Provider>
   );
 }
 
-function ReplyContent({ reply }: ReplyItemProps) {
-  const { openReplyForm } = useReplyListContext('ReplyContent');
+interface ReplyContentProps {
+  onOpenReplyForm?: () => void;
+}
+
+function ReplyContent({ onOpenReplyForm }: ReplyContentProps) {
+  const { reply } = useReplyItemContext('ReplyContent');
   const { isLogIn } = useSelector((state: AppState) => state.user);
+  const isReplyButtonVisible = useMemo(
+    () => isLogIn && !reply.parentReply && onOpenReplyForm,
+    [isLogIn, reply, onOpenReplyForm],
+  );
   const isEdited = useMemo(
     () => reply.createdDate !== reply.modifiedDate,
     [reply],
@@ -106,14 +72,15 @@ function ReplyContent({ reply }: ReplyItemProps) {
 
   return (
     <Styled.ReplyContentContainer>
+      <Styled.Author>{reply.userId}</Styled.Author>
       <Styled.Content>{reply.content}</Styled.Content>
       <Styled.DetailWrapper>
         <span>
           {elapsedTime(`${reply.modifiedDate} UTC`)}
           {isEdited && ' • 수정됨'}
         </span>
-        {isLogIn && !reply.parentReply && (
-          <button type="button" onClick={() => openReplyForm(reply.id)}>
+        {isReplyButtonVisible && (
+          <button type="button" onClick={onOpenReplyForm}>
             답글쓰기
           </button>
         )}
@@ -122,16 +89,13 @@ function ReplyContent({ reply }: ReplyItemProps) {
   );
 }
 
-interface ReplyContentEditorProps extends ReplyItemProps {
+interface ReplyContentEditorProps {
   onUpdate: (data: ReplySchema) => void;
   onCancel: () => void;
 }
 
-function ReplyContentEditor({
-  reply,
-  onUpdate,
-  onCancel,
-}: ReplyContentEditorProps) {
+function ReplyContentEditor({ onUpdate, onCancel }: ReplyContentEditorProps) {
+  const { reply } = useReplyItemContext('ReplyContentEditor');
   const {
     register,
     handleSubmit,
@@ -145,19 +109,52 @@ function ReplyContentEditor({
   });
 
   return (
-    <form onSubmit={handleSubmit(onUpdate)}>
-      <Styled.ContentTextArea
-        placeholder="수정할 댓글을 입력해주세요."
-        {...register('content')}
-      />
-      <Styled.EditUtilWrapper>
-        <Button variant="default" size="sm" onClick={onCancel}>
-          취소
-        </Button>
-        <Button type="submit" size="sm" disabled={!isValid || !isDirty}>
-          수정
-        </Button>
-      </Styled.EditUtilWrapper>
-    </form>
+    <Styled.ReplyContentEditorContainer>
+      <Styled.Author>
+        <Styled.EditIndicator>수정중</Styled.EditIndicator>
+        {reply.userId}
+      </Styled.Author>
+      <form onSubmit={handleSubmit(onUpdate)}>
+        <Styled.ContentTextArea
+          placeholder="수정할 댓글을 입력해주세요."
+          {...register('content')}
+        />
+        <Styled.EditUtilWrapper>
+          <Button type="submit" size="sm" disabled={!isValid || !isDirty}>
+            수정
+          </Button>
+          <Button variant="default" size="sm" onClick={onCancel}>
+            취소
+          </Button>
+        </Styled.EditUtilWrapper>
+      </form>
+    </Styled.ReplyContentEditorContainer>
   );
 }
+
+interface ReplyDropdownProps {
+  onUpdate?: () => void;
+  onDelete?: () => void;
+}
+
+function ReplyDropdown({ onUpdate, onDelete }: ReplyDropdownProps) {
+  return (
+    <Styled.UtilWrapper>
+      <Dropdown>
+        <Dropdown.Button>
+          <SVGIcon icon="MoreVerticalIcon" />
+        </Dropdown.Button>
+        <Dropdown.Items width="8rem">
+          <Dropdown.Item onClick={onUpdate}>수정하기</Dropdown.Item>
+          <Dropdown.Item onClick={onDelete}>삭제하기</Dropdown.Item>
+        </Dropdown.Items>
+      </Dropdown>
+    </Styled.UtilWrapper>
+  );
+}
+
+export default Object.assign(ReplyItem, {
+  Content: ReplyContent,
+  ContentEditor: ReplyContentEditor,
+  Dropdown: ReplyDropdown,
+});

--- a/components/reply/ReplyItem/ReplyItem.tsx
+++ b/components/reply/ReplyItem/ReplyItem.tsx
@@ -109,7 +109,6 @@ function ReplyContent({ reply }: ReplyItemProps) {
       <Styled.Content>{reply.content}</Styled.Content>
       <Styled.DetailWrapper>
         <span>
-          {format(new Date(`${reply.modifiedDate} UTC`), 'yyyy.MM.dd hh:mm')}
           {elapsedTime(`${reply.modifiedDate} UTC`)}
           {isEdited && ' • 수정됨'}
         </span>

--- a/components/reply/ReplyList/index.ts
+++ b/components/reply/ReplyList/index.ts
@@ -1,2 +1,0 @@
-export { default } from './ReplyList';
-export * from './ReplyList';


### PR DESCRIPTION
# Pull Request
 - [x] Refactoring
 
 # Summary
- 댓글 컴포넌트 리팩터링

# Describe your changes
- `ReplyItem` 컴포넌트를 `ReplyItem.Content`와 `ReplyItem.ContentEditor`로 외부의 상태로 다른 컴포넌트를 렌더링 하도록 수정
- 기존 PostPage의 댓글리스트를 `PostReplyList`로 변경


# Examples
다음과 같이 외부의 상태로 에디터인지 아닌지를 구분하도록 변경
아래는 Pseudo Code
```tsx
function PostReply(){
  const [isEditalbe, setIsEditable] = useState<boolean>(false);
  
  return (
    <ReplyItem reply={reply}>
      {
        isEditalbe ? (
          <ReplyItem.ContentEditor />
        ) : (
          <ReplyItem.Content />
        )
      }
    </ReplyItem>
  )
}
```


